### PR TITLE
[v0.2.0] KDE-62 AuthInterceptor 순환참조 해결을 위한 UserInfoProviver 분리

### DIFF
--- a/src/main/java/com/kookdonge/kookdonge_server/auth/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/kookdonge/kookdonge_server/auth/interceptor/AuthInterceptor.java
@@ -2,7 +2,7 @@ package com.kookdonge.kookdonge_server.auth.interceptor;
 
 import com.kookdonge.kookdonge_server.auth.common.AuthExceptionCode;
 import com.kookdonge.kookdonge_server.auth.common.JWT;
-import com.kookdonge.kookdonge_server.auth.service.UserService;
+import com.kookdonge.kookdonge_server.auth.service.UserInfoProvider;
 import com.kookdonge.kookdonge_server.auth.service.annotation.LoginRequired;
 import com.kookdonge.kookdonge_server.common.exception.CustomException;
 import com.kookdonge.kookdonge_server.common.info.UserInfoStore;
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class AuthInterceptor implements HandlerInterceptor {
 
     private final JWT jwt;
-    private final UserService userService;
+    private final UserInfoProvider userInfoProvider;
 
     @Override
     public boolean preHandle(
@@ -35,8 +35,8 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         if (isLoginRequired(handlerMethod)) {
             String externalUserId = extractExternalUserIdFromToken(request);
-            Long userId = userService.getUserIdByExternalUserId(externalUserId);
-            Long clubId = userService.getClubIdByUserId(userId);
+            Long userId = userInfoProvider.getUserIdByExternalUserId(externalUserId);
+            Long clubId = userInfoProvider.getClubIdByUserId(userId);
             UserInfoStore.set(userId, clubId);
         }
 

--- a/src/main/java/com/kookdonge/kookdonge_server/auth/service/UserInfoProvider.java
+++ b/src/main/java/com/kookdonge/kookdonge_server/auth/service/UserInfoProvider.java
@@ -1,0 +1,27 @@
+package com.kookdonge.kookdonge_server.auth.service;
+
+import com.kookdonge.kookdonge_server.auth.common.AuthExceptionCode;
+import com.kookdonge.kookdonge_server.auth.infra.jpa.entity.UserEntity;
+import com.kookdonge.kookdonge_server.auth.infra.jpa.repository.UserRepository;
+import com.kookdonge.kookdonge_server.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserInfoProvider {
+
+    private final UserRepository userRepository;
+
+    // AuthInterceptor에서 사용하기 위해서 만듬
+    public Long getUserIdByExternalUserId(String externalUserId){
+        UserEntity savedUserEntity = userRepository.findByExternalUserId(externalUserId)
+                .orElseThrow(() -> new CustomException(AuthExceptionCode.USER_NOT_FOUND));
+        return savedUserEntity.getUserId();
+    }
+    public Long getClubIdByUserId(Long userId){
+        UserEntity savedUserEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthExceptionCode.USER_NOT_FOUND));
+        return savedUserEntity.getClubId();
+    }
+}

--- a/src/main/java/com/kookdonge/kookdonge_server/auth/service/UserService.java
+++ b/src/main/java/com/kookdonge/kookdonge_server/auth/service/UserService.java
@@ -101,16 +101,4 @@ public class UserService {
                 refreshToken);
     }
 
-    // AuthInterceptor에서 사용하기 위해서 만듬
-    public Long getUserIdByExternalUserId(String externalUserId){
-        UserEntity savedUserEntity = userRepository.findByExternalUserId(externalUserId)
-                .orElseThrow(() -> new CustomException(AuthExceptionCode.USER_NOT_FOUND));
-        return savedUserEntity.getUserId();
-    }
-    public Long getClubIdByUserId(Long userId){
-        UserEntity savedUserEntity = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(AuthExceptionCode.USER_NOT_FOUND));
-        return savedUserEntity.getClubId();
-    }
-
 }

--- a/src/main/java/com/kookdonge/kookdonge_server/common/config/WebConfig.java
+++ b/src/main/java/com/kookdonge/kookdonge_server/common/config/WebConfig.java
@@ -1,12 +1,17 @@
 package com.kookdonge.kookdonge_server.common.config;
 
+import com.kookdonge.kookdonge_server.auth.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -15,4 +20,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP method
                 .allowCredentials(true); // 쿠키 인증 요청 허용
     }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**");
+    }
+
 }


### PR DESCRIPTION
┌─────┐
|  authInterceptor defined in file [/Users/tth/kookdonge/kookdonge_server/build/classes/java/main/com/kookdonge/kookdonge_server/auth/interceptor/AuthInterceptor.class]
↑     ↓
|  userService defined in file [/Users/tth/kookdonge/kookdonge_server/build/classes/java/main/com/kookdonge/kookdonge_server/auth/service/UserService.class]
↑     ↓
|  com.kookdonge.kookdonge_server.auth.service.client.GoogleOAuthClient
↑     ↓
|  org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$EnableWebMvcConfiguration
↑     ↓
|  webConfig defined in file [/Users/tth/kookdonge/kookdonge_server/build/classes/java/main/com/kookdonge/kookdonge_server/common/config/WebConfig.class]
└─────┘